### PR TITLE
ct: Pull out `omit`.  Add basic tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.project
+node_modules

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@
  *
  */
 
+var extend = require("./lib/extend");
+
 module.exports = function () {
 	return new NanoDocUpdater();
 };
@@ -87,13 +89,6 @@ function useNewVersion(existing, newVer) {
 	return newVer;
 }
 
-/* Shallow object copy. */
-function extend(target, source) {
-	Object.getOwnPropertyNames(source).forEach(function (e) {
-		target[e] = source[e];
-	});
-	return target;
-}
 
 function omit(source, blacklist) {
 	var result = {};
@@ -138,7 +133,7 @@ function updateDocument(existingDoc, newDoc, id, db, f_ShouldUpdate, shouldCreat
 						return callback("Could not fetch existing document: " + err.toString());
 
 					// The insert worked.  We're done.
-					return callback(null, extend(newDoc, {_rev: r.rev}));
+					return callback(null, extend({}, newDoc, {_rev: r.rev}));
 				});
 			}
 
@@ -165,7 +160,7 @@ function updateDocument(existingDoc, newDoc, id, db, f_ShouldUpdate, shouldCreat
 
 	// It's essential that we specify a revision or this will never terminate.
 	// It's probably not a good idea to trust a user-specified merge function to do this.
-	mergedDoc = extend(mergedDoc, { _rev: existingDoc._rev });
+	mergedDoc = extend({}, mergedDoc, { _rev: existingDoc._rev });
 
 	// The document exists, and is out of date.  We need to overwrite it.
 	db.insert(

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -1,0 +1,11 @@
+/* Shallow object copy. */
+module.exports = function (target /*, sources ... */) {
+        for (var i=1; i<arguments.length; i++) {
+            var source = arguments[i];
+
+            Object.getOwnPropertyNames(source).forEach(function (e) {
+                    target[e] = source[e];
+            });
+        }
+	return target;
+};

--- a/package.json
+++ b/package.json
@@ -1,14 +1,25 @@
 {
-    "name": "nano-doc-updater",
-    "version": "0.0.2",
-    "description": "Performs insert-updates of a couchdb document with configurable conflict resolution.",
-    "author": "Chris Taylor <cntaylor@ca.ibm.com>",
-    "license": "MIT",
-    "keywords": [ "nano", "update", "insert", "merge" ],
-    "repository": {
-	"type": "git",
-	"url": "https://github.com/IBM/node-nano-doc-updater"
-    },
-    "main": "index.js",
-    "homepage": "https://github.com/IBM/node-nano-doc-updater/releases"
+  "name": "nano-doc-updater",
+  "version": "0.0.2",
+  "description": "Performs insert-updates of a couchdb document with configurable conflict resolution.",
+  "author": "Chris Taylor <cntaylor@ca.ibm.com>",
+  "license": "MIT",
+  "keywords": [
+    "nano",
+    "update",
+    "insert",
+    "merge"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IBM/node-nano-doc-updater"
+  },
+  "main": "index.js",
+  "homepage": "https://github.com/IBM/node-nano-doc-updater/releases",
+  "devDependencies": {
+    "nano": "^6.2.0",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.2",
+    "tape-catch": "^1.0.6"
+  }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+    "rules": {
+        "indent": [
+            2,
+            4
+        ],
+        "quotes": [
+            2,
+            "double"
+        ],
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "semi": [
+            2,
+            "always"
+        ]
+    },
+    "env": {
+        "es6": true,
+        "node": true
+    },
+    "extends": "eslint:recommended"
+}

--- a/test/test-extend.js
+++ b/test/test-extend.js
@@ -1,0 +1,56 @@
+var test = require("tape-catch"),
+    extend = require("../lib/extend");
+
+test("extending an empty object with a single empty object...", function (t) {
+    var o1 = {};
+    extend(o1, {});
+    t.deepEqual(o1, {}, "...results in an empty object");
+    t.end();
+});
+
+test("extending an empty object with several empty objects...", function (t) {
+    var o1 = {};
+    extend(o1, {}, {}, {});
+    t.deepEqual(o1, {}, "...results in an empty object");
+    t.end();
+});
+
+test("extending an empty object with a non-empty object...", function (t) {
+    var o1 = {},
+        o2 = { a: 1 };
+
+    extend(o1, o2);
+    t.deepEqual(o1, o2, "...results in clone of the non-empty object");
+    t.end();
+});
+
+test("extending an empty object with several non-empty objects ", function (t) {
+    var o1 = {},
+        o2 = { a: 1 },
+        o3 = { b: 2 },
+        intended = { a: 1, b: 2 };
+
+    extend(o1, o2, o3);
+    t.deepEqual(o1, intended, "...results in an object merging all of the source objects' elements");
+    t.end();
+});
+
+test("extending an object with a source object that contains overlapping keys...", function (t) {
+    var o1 =        { a: "old", b: "older", c: "oldest" },
+        o2 =        { a: "new", b: "newer" },
+        merged =    { a: "new", b: "newer", c: "oldest"};
+
+    extend(o1, o2);
+
+    t.deepEqual(o1, merged, "...results in a properly merged object");
+    t.end();
+});
+
+test("extend() returns...", function (t) {
+    var o1 = {};
+    var o2 = {};
+    var extendResult = extend(o1, o2);
+    t.equal(o1, extendResult, "...the target object (first argument)");
+    t.notEqual(o2, extendResult, "...not the first source object (second argument)");
+    t.end();
+});

--- a/test/test-nano-doc-updater.js
+++ b/test/test-nano-doc-updater.js
@@ -1,0 +1,99 @@
+var test = require("tape-catch"),
+    Promise = require("bluebird"),
+    nano = require("nano"),
+    nanoDocUpdater = require("../");
+
+test("sanity - after wiping the DB...", (t) => {
+    resetTestDB()
+    .then((db) => {
+        db = Promise.promisifyAll(db);
+        return db.listAsync();
+    })
+    .then((r) => {
+        var body = r[0];
+
+        t.deepEquals(body.rows, [], "...is the db empty?");
+    })
+    .catch((e) => {
+        if (e instanceof Error) {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        } else {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        }
+
+        throw(e);
+    })
+    .finally(() => {
+        t.end();
+    });
+});
+
+test("after updating a document that didn't already exist...", (t) => {
+    var db = null;
+    var docId = "a";
+    var doc = { a: 1 };
+
+    resetTestDB()
+    .then((rawDb) => {
+        db = Promise.promisifyAll(rawDb);
+
+        var updater = nanoDocUpdater()
+        .db(rawDb)
+        .newDoc(doc)
+        .id(docId);
+
+        return Promise.promisify(updater.update, updater)();
+    })
+    .then(() => {
+        return db.getAsync(docId);
+    })
+    .then((r) => {
+        var d = r[0];
+
+        t.equal(d._id, "a", "...does the inserted document id match what we provided to NanoDocUpdater?");
+        t.equal(d.a, doc.a, "...does the field in the inserted document match what we provided to NanoDocUpdater?");
+    })
+    .catch((e) => {
+        if (e instanceof Error) {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        } else {
+            t.comment(e.stack);
+            t.fail("...an error occurred");
+        }
+
+        throw(e);
+    })
+    .finally(() => {
+        t.end();
+    });
+});
+
+// Returns a Promise that resolves with a handle to a blank testing DB.
+function resetTestDB() {
+    var DB_NAME = "test",
+        n = null;
+
+    return Promise.try(() => {
+        if (!process.env.DB) {
+            throw new Error("DB envvar is undefinied");
+        }
+
+        n = nano(process.env.DB);
+        return Promise.promisify(n.db.destroy)("test");
+    })
+    .catch(NanoNotFoundError, (e) => {})
+    .then(() => {
+        return Promise.promisify(n.db.create)("test");
+    })
+    .then(() => {
+        return n.use(DB_NAME);
+    });
+}
+
+// Returns true iff the provided error is a Nano "Not Found" error.
+function NanoNotFoundError(e) {
+    return e && e.error == "not_found";
+} 


### PR DESCRIPTION
- Enhance `omit()` so that it can take an arbitrary number of arguments.
- Move `omit()` to its own library and add some unit tests.
- Add a very basic unit test to validate nano-doc-updater (WIP; more to
  come; also, directions on running the tests to come as well).
- Enhance original PR to ensure we don't modify objects the
  nano-doc-updater is given.